### PR TITLE
Remove deprecated option from gemspec

### DIFF
--- a/silverpop.gemspec
+++ b/silverpop.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.description = "Silverpop allows for seamless integration from Ruby with the Engage and Transact API."
   s.authors  = ["George Truong, Bill Abney, Mario Zaizar, Sergey Gopkalo"]
 
-  s.has_rdoc = false
   s.rdoc_options = ["--main", "README.md"]
   s.extra_rdoc_files = ["README.md"]
 


### PR DESCRIPTION
When bundling the gem: 

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /usr/local/Cellar/asdf/0.5.1/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/silverpop-1b09f53bf2dc/silverpop.gemspec:11.
```